### PR TITLE
Improve title case maker to handle kebab-case

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -207,7 +207,7 @@ fn make_title_case(name: &str) -> String {
         &name
             .chars()
             .skip_while(|c| !c.is_alphabetic())
-            .map(|c| if c == '_' { ' ' } else { c })
+            .map(|c| if ['_', '-'].contains(&c) { ' ' } else { c })
             .collect::<String>(),
     )
 }
@@ -220,6 +220,7 @@ mod tests {
     fn titlecase_test() {
         assert_eq!("Chapter 1", make_title_case("1-chapter_1"));
         assert_eq!("Chapter 23", make_title_case("chapter_23"));
+        assert_eq!("Chapter 25", make_title_case("chapter-25"));
     }
 
     #[test]


### PR DESCRIPTION
I believe it makes sense to also handle `kebab-case` filenames, because they're fairly common.

### Before

`migration-guidelines.md` -> `Migration-Guidelines`

### After

`migration-guidelines.md` -> `Migration Guidelines`